### PR TITLE
Fix blame

### DIFF
--- a/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/db/IdTuple.java
+++ b/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/db/IdTuple.java
@@ -137,8 +137,12 @@ public class IdTuple
 			for(int i=0; i<=level; i++) {
 				if (i>0)
 					buff += " ";
+				String strIndex = String.valueOf(index[i]);
 				
-				buff += IdTupleType.kindStr(kind[i]) + " " + index[i];
+				if (kind[i] == IdTupleType.KIND_NODE) {
+					strIndex = Long.toHexString(index[i]);
+				}
+				buff += IdTupleType.kindStr(kind[i]) + " " + strIndex;
 			}
 		return buff;
 	}

--- a/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/util/LargeByteBuffer.java
+++ b/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/util/LargeByteBuffer.java
@@ -152,7 +152,7 @@ public class LargeByteBuffer
 
 		// combine the higher and lower bytes, convert them to a long
 		
-		assert(byteLeft.length + byteLeft.length == numBytes);
+		assert(byteLeft.length + byteRight.length == numBytes);
 		
 		byte []resultByte = new byte[Long.BYTES];
 		for (int i=0; i<byteLeft.length; i++) {

--- a/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/util/LargeByteBuffer.java
+++ b/edu.rice.cs.hpc.data/src/edu/rice/cs/hpc/data/util/LargeByteBuffer.java
@@ -1,6 +1,7 @@
 package edu.rice.cs.hpc.data.util;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -97,29 +98,86 @@ public class LargeByteBuffer
 	{
 		int page = (int) (position / pageSize);
 		int loc = (int) (position % pageSize);
-		return getBuffer(page).getInt(loc);
+		long remainder = pageSize - loc;
+
+		if (remainder >= Integer.BYTES) {
+			return getBuffer(page).getInt(loc);
+		}
+		ByteBuffer bb = combineBytes(page, loc, Integer.BYTES);
+		return bb.getInt();
 	}
 	
 	public long getLong(long position) throws IOException
 	{
 		int page = (int) (position / pageSize);
 		int loc = (int) (position % pageSize);
-		if (loc < pageSize - 4) {
+
+		long remainder = pageSize - loc;
+		if (remainder >= Long.BYTES) {
 			return getBuffer(page).getLong(loc);
-		} else {
-			return (((long) getBuffer(page).getInt(loc)) << 32) + getBuffer(page+1).getInt(0);
 		}
+		ByteBuffer bb = combineBytes(page, loc, Long.BYTES);
+		long result = bb.getLong();
+		
+		return result;
 	}
+	
+	
+	/****
+	 * This method combines last bytes of the "first" page and the first bytes of the "second" page.
+	 * In some cases, we need to read more bytes than the allocated bytes of a page. 
+	 * For example the number of bytes in a page is 1024, and at location 1022 we want to read 
+	 * 8 bytes. This causes we need to read 2 bytes in the current page, and another 6 bytes in the next
+	 * page.
+	 * 
+	 * @param page int the current page
+	 * @param loc long the current location
+	 * @param numBytes int the number of bytes we need to read
+	 * @return {@code ByteBuffer} byte buffer of the read bytes. The size is equal to numBytes.
+	 * @throws IOException
+	 */
+	private ByteBuffer combineBytes(int page, int loc, int numBytes) throws IOException {
+		long remainder = pageSize - loc;
+
+		// graph the higher bytes
+		byte []byteLeft = new byte[(int) remainder];
+		for (int i=0; i<remainder; i++) {
+			byteLeft[i] = getBuffer(page).get(loc+i);
+		}
+
+		// grab the lower bytes
+		int remRight = (int) (numBytes - remainder);
+		byte []byteRight = new byte[remRight];
+		getBuffer(page+1).get(byteRight);
+
+		// combine the higher and lower bytes, convert them to a long
+		
+		assert(byteLeft.length + byteLeft.length == numBytes);
+		
+		byte []resultByte = new byte[Long.BYTES];
+		for (int i=0; i<byteLeft.length; i++) {
+			resultByte[i] = byteLeft[i];
+		}
+		for (int i=0; i<byteRight.length; i++) {
+			resultByte[i+byteLeft.length] = byteRight[i];
+		}
+		
+		return ByteBuffer.wrap(resultByte);
+	}
+	
 	
 	public double getDouble(long position) throws IOException
 	{
 		int page = (int) (position / pageSize);
 		int loc = (int) (position % pageSize);
-		if (loc < pageSize - 4) {
+
+		long remainder = pageSize - loc; 
+		if (remainder >= Double.BYTES) {
 			return getBuffer(page).getDouble(loc);
-		} else {
-			return (double)(((long) getBuffer(page).getInt(loc)) << 32) + (long) getBuffer(page+1).getInt(0);
 		}
+		ByteBuffer bb = combineBytes(page, loc, Double.BYTES);
+		double result = bb.getDouble();
+		return result;
 	}
 	
 	public char getChar(long position) throws IOException
@@ -143,14 +201,28 @@ public class LargeByteBuffer
 	{
 		int page = (int) (position / pageSize);
 		int loc = (int) (position % pageSize);
-		return getBuffer(page).getFloat(loc);
+		
+		long remainder = pageSize - loc; 
+		if (remainder >= Float.BYTES) {
+			return getBuffer(page).getFloat(loc);
+		}
+		ByteBuffer bb = combineBytes(page, loc, Float.BYTES);
+		float result = bb.getFloat();
+		return result;
 	}
 	
 	public short getShort(long position) throws IOException
 	{
 		int page = (int) (position / pageSize);
 		int loc = (int) (position % pageSize);
-		return getBuffer(page).getShort(loc);
+		
+		long remainder = pageSize - loc; 
+		if (remainder >= Short.BYTES) {
+			return getBuffer(page).getShort(loc);
+		}
+		ByteBuffer bb = combineBytes(page, loc, Float.BYTES);
+		short result = bb.getShort();
+		return result;
 	}
 	
 	public long size()

--- a/edu.rice.cs.hpctoolcontrol/src/edu/rice/cs/hpctoolcontrol/ToolControl.java
+++ b/edu.rice.cs.hpctoolcontrol/src/edu/rice/cs/hpctoolcontrol/ToolControl.java
@@ -16,7 +16,6 @@ import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.ProgressBar;
@@ -31,7 +30,6 @@ public class ToolControl
 {
 	private final UISynchronize sync;
 
-	private Canvas memory;
 	private ProgressBar progressBar;
 	private GobalProgressMonitor monitor;
 	private Label lblMessage;
@@ -155,6 +153,11 @@ public class ToolControl
 				});
 			}
 			return this;
+		}
+		
+		@Override
+		public void setTaskName(String name) {
+			lblMessage.setText(name);
 		}
 	}
 }

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/TracePart.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/TracePart.java
@@ -300,7 +300,7 @@ public class TracePart implements ITracePart, IPartListener, IPropertyChangeList
 			tbtmCallStack.setInput(stdc);
 			miniCanvas.   updateView(stdc);
 			tbtmStatView .setInput(stdc);
-			tbtmBlameView  .setInput(stdc);
+			tbtmBlameView.setInput(stdc);
 			
 			// TODO: summary view has to be set AFTER the stat view 
 			//       since the stat view requires info from summary view 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/HPCBlameView.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/HPCBlameView.java
@@ -1,7 +1,6 @@
 package edu.rice.cs.hpctraceviewer.ui.blamestat;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -45,6 +44,7 @@ import edu.rice.cs.hpcsetting.preferences.ViewerPreferenceManager;
 import edu.rice.cs.hpctraceviewer.data.ColorTable;
 import edu.rice.cs.hpctraceviewer.ui.base.AbstractBaseItem;
 import edu.rice.cs.hpctraceviewer.ui.base.ITracePart;
+import edu.rice.cs.hpctraceviewer.ui.preferences.TracePreferenceManager;
 import edu.rice.cs.hpctraceviewer.ui.summary.SummaryData;
 import edu.rice.cs.hpctraceviewer.ui.util.IConstants;
 
@@ -102,7 +102,7 @@ public class HPCBlameView extends    AbstractBaseItem
 		colCount.setLabelProvider(new ColumnStatLabelProvider());
 		
 		column = colCount.getColumn();
-		layout.setColumnData(column, new ColumnWeightData(200, 40, true));
+		layout.setColumnData(column, new ColumnWeightData(200, 30, true));
 		
 		column.setText("%");
 		column.setAlignment(SWT.RIGHT);
@@ -181,7 +181,7 @@ public class HPCBlameView extends    AbstractBaseItem
 
 		tableViewer.setInput(listItems);
 		tableViewer.refresh();
-		tableViewer.getTable().getColumn(1).pack();
+		//tableViewer.getTable().getColumn(1).pack();
 	}
 	
 
@@ -303,7 +303,7 @@ public class HPCBlameView extends    AbstractBaseItem
 		
 		@Override
 		public int getToolTipDisplayDelayTime(Object object) {
-    		return IConstants.TOOLTIP_DELAY_MS;
+    		return TracePreferenceManager.getTooltipDelay();
 		}
 	}
 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/HPCBlameView.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/HPCBlameView.java
@@ -2,6 +2,8 @@ package edu.rice.cs.hpctraceviewer.ui.blamestat;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -100,7 +102,7 @@ public class HPCBlameView extends    AbstractBaseItem
 		colCount.setLabelProvider(new ColumnStatLabelProvider());
 		
 		column = colCount.getColumn();
-		layout.setColumnData(column, new ColumnWeightData(200, 30, true));
+		layout.setColumnData(column, new ColumnWeightData(200, 40, true));
 		
 		column.setText("%");
 		column.setAlignment(SWT.RIGHT);
@@ -143,30 +145,6 @@ public class HPCBlameView extends    AbstractBaseItem
 	}
 	
 	
-	
-	private void listItemsAttributeBlame(
-			PaletteData palette, 
-			ColorTable colorTable,
-			TreeMap<Integer, Float> blameMap, 		
-			float totalBlame) {
-		
-		Set<Integer> set = blameMap.keySet();		
-		
-		for(Iterator<Integer> it = set.iterator(); it.hasNext(); ) {
-			final Integer pixel = it.next();
-			final Float count   = blameMap.get(pixel);
-			final RGB rgb	 	= palette.getRGB(pixel);
-			
-			String proc = colorTable.getProcedureNameByColorHash(rgb.hashCode());
-			if (proc == null) {
-				proc = ColorTable.UNKNOWN_PROCNAME;
-			}
-			
-			listItems.add(new StatisticItem(proc, (float) 100.0 * count / totalBlame));
-		}
-	}
-	
-	
 	/**
 	 * Refresh the content of the viewer and reinitialize the content
 	 *  with the new data
@@ -186,15 +164,21 @@ public class HPCBlameView extends    AbstractBaseItem
 		
 		this.colorTable = colorTable;
 		this.listItems  = new ArrayList<>();
-				
 		
-//		listItems.add(new StatisticItem("CPU_BLAME", (float) 100));
-		listItemsAttributeBlame(palette, colorTable, cpuBlameMap, totalCpuBlame);
+		Set<Entry<Integer, Float>> entries = cpuBlameMap.entrySet();
 		
-//		listItems.add(new StatisticItem("GPU_BLAME", (float) 100));
-//		listItemsAttributeBlame(palette, colorTable, gpuBlameMap, totalGpuBlame);
-		
-		
+		for(Map.Entry<Integer, Float> entry: entries ) {
+			final Integer pixel = entry.getKey();
+			final Float count   = entry.getValue();
+			final RGB rgb	 	= palette.getRGB(pixel);
+			
+			String proc = colorTable.getProcedureNameByColorHash(rgb.hashCode());
+			if (proc == null) {
+				proc = ColorTable.UNKNOWN_PROCNAME;
+			}			
+			listItems.add(new StatisticItem(proc, (float) 100.0 * count / totalCpuBlame));
+		}
+
 		tableViewer.setInput(listItems);
 		tableViewer.refresh();
 		tableViewer.getTable().getColumn(1).pack();
@@ -344,12 +328,7 @@ public class HPCBlameView extends    AbstractBaseItem
 
 
 	@Override
-	public void handleEvent(org.eclipse.swt.widgets.Event event) {
-		System.out.println(getClass().getName() + " show-idx: "  + event.index + ", show-w: " + event.widget);
-		if (tableViewer == null) return;
-		if (tableViewer.getTable().getItemCount() < 1) {
-		}
-	}
+	public void handleEvent(org.eclipse.swt.widgets.Event event) {}
 
 
 	@Override

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/depth/DepthTimeCanvas.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/depth/DepthTimeCanvas.java
@@ -97,7 +97,7 @@ public class DepthTimeCanvas extends AbstractTimeCanvas
 	{
 		bound = getClientArea();
 
-		if (stData == null || !stData.isTimelineFilled())
+		if (stData == null )
 			return;
 		
 		if (needToRedraw) {

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/SpaceTimeDetailCanvas.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/SpaceTimeDetailCanvas.java
@@ -6,7 +6,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.security.KeyStore.Entry.Attribute;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.List;

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/preferences/TracePreferenceManager.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/preferences/TracePreferenceManager.java
@@ -30,11 +30,27 @@ public class TracePreferenceManager extends AbstractPreferenceManager
 		return renderOption == TracePreferenceConstants.RENDERING_MIDPOINT;
 	}
 	
-	private static int getRenderOption() {
-		return INSTANCE.getPreferenceStore().getInt(TracePreferenceConstants.PREF_RENDER_OPTION);
-	}
 	
+	/***
+	 * 
+	 * @return
+	 */
 	public static int getMaxThreads() {
 		return INSTANCE.getPreferenceStore().getInt(TracePreferenceConstants.PREF_MAX_THREADS);
+	}
+	
+	public static int getTooltipDelay() {
+		return INSTANCE.getPreferenceStore().getInt(TracePreferenceConstants.PREF_TOOLTIP_DELAY);
+	}
+
+	
+	////////////////////////////////////////
+	// 
+	// Private methods
+	//
+	////////////////////////////////////////
+
+	private static int getRenderOption() {
+		return INSTANCE.getPreferenceStore().getInt(TracePreferenceConstants.PREF_RENDER_OPTION);
 	}
 }

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/statistic/HPCStatView.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/statistic/HPCStatView.java
@@ -43,6 +43,7 @@ import edu.rice.cs.hpcsetting.preferences.ViewerPreferenceManager;
 import edu.rice.cs.hpctraceviewer.data.ColorTable;
 import edu.rice.cs.hpctraceviewer.ui.base.AbstractBaseItem;
 import edu.rice.cs.hpctraceviewer.ui.base.ITracePart;
+import edu.rice.cs.hpctraceviewer.ui.preferences.TracePreferenceManager;
 import edu.rice.cs.hpctraceviewer.ui.summary.SummaryData;
 import edu.rice.cs.hpctraceviewer.ui.util.IConstants;
 
@@ -295,7 +296,7 @@ public class HPCStatView extends    AbstractBaseItem
 		
 		@Override
 		public int getToolTipDisplayDelayTime(Object object) {
-    		return IConstants.TOOLTIP_DELAY_MS;
+    		return TracePreferenceManager.getTooltipDelay();
 		}
 	}
 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/statistic/HPCStatView.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/statistic/HPCStatView.java
@@ -175,7 +175,7 @@ public class HPCStatView extends    AbstractBaseItem
 		}
 		tableViewer.setInput(listItems);
 		tableViewer.refresh();
-		tableViewer.getTable().getColumn(1).pack();
+		//tableViewer.getTable().getColumn(1).pack();
 	}
 	
 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/summary/SummaryTimeCanvas.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/summary/SummaryTimeCanvas.java
@@ -386,31 +386,32 @@ public class SummaryTimeCanvas extends AbstractTimeCanvas implements IOperationH
 
 	@Override
 	public void historyNotification(final OperationHistoryEvent event) {
-		// we are not interested with other operation
+
+		if (isDisposed())
+			return;
+
+		// we are not interested with other operation contexts
 		IUndoContext context = tracePart.getContext(BaseTraceContext.CONTEXT_OPERATION_BUFFER);
+		if (!event.getOperation().hasContext(context)) 
+			return;
+		
+		if (event.getEventType() == OperationHistoryEvent.DONE) {
 
-		if (event.getOperation().hasContext(context)) {
-			if (event.getEventType() == OperationHistoryEvent.DONE) {
-
-				if (isDisposed())
-					return;
-
-				final IUndoableOperation operation = event.getOperation();
-				if (!(operation instanceof AbstractTraceOperation)) {
-					return;
-				}
-				AbstractTraceOperation op = (AbstractTraceOperation) operation;
-				if (op.getData() != dataTraces)
-					return;
-
-				getDisplay().syncExec(new Runnable() {
-					@Override
-					public void run() {
-						BufferRefreshOperation operation = (BufferRefreshOperation) event.getOperation();
-						refresh(operation.getImageData());
-					}
-				});
+			final IUndoableOperation operation = event.getOperation();
+			if (!(operation instanceof AbstractTraceOperation)) {
+				return;
 			}
+			final AbstractTraceOperation op = (AbstractTraceOperation) operation;
+			if (op.getData() != dataTraces)
+				return;
+
+			getDisplay().syncExec(new Runnable() {
+				@Override
+				public void run() {
+					BufferRefreshOperation operation = (BufferRefreshOperation) op;
+					refresh(operation.getImageData());
+				}
+			});
 		}
 	}
 
@@ -423,10 +424,10 @@ public class SummaryTimeCanvas extends AbstractTimeCanvas implements IOperationH
 		final ImageTraceAttributes attributes = dataTraces.getAttributes();
 
 		long timeBegin = attributes.getTimeBegin();
-		int left = region.x;
+		int left  = region.x;
 		int right = region.width + region.x;
 
-		long topLeftTime = timeBegin + (long) (left / getScalePixelsPerTime());
+		long topLeftTime     = timeBegin + (long) (left  / getScalePixelsPerTime());
 		long bottomRightTime = timeBegin + (long) (right / getScalePixelsPerTime());
 
 		final Position position = attributes.getPosition();

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/util/IConstants.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/util/IConstants.java
@@ -3,13 +3,11 @@ package edu.rice.cs.hpctraceviewer.ui.util;
 public interface IConstants 
 {
 	public static final String TOPIC_STATISTICS    = "trace/stat";
-	public static final String TOPIC_BLAME    = "trace/blame";
+	public static final String TOPIC_BLAME         = "trace/blame";
 	public static final String TOPIC_DEPTH_UPDATE  = "trace/depth/update";
 	public static final String TOPIC_FILTER_RANKS  = "trace/filter";
 	public static final String TOPIC_COLOR_MAPPING = "trace/colorMap";
 
-	public static final String URI_CONTRIBUTOR    = "platform:/plugin/edu.rice.cs.hpctraceviewer.ui";
+	public static final String URI_CONTRIBUTOR     = "platform:/plugin/edu.rice.cs.hpctraceviewer.ui";
 	public static final String ID_DATA_OPERATION   = "trace/op/undo";
-
-	public static final int    TOOLTIP_DELAY_MS  = 2000;
 }


### PR DESCRIPTION
- Update blame-shifting so it doesn't break the summary view. The latter needs to show the idleness, while the original blame-shifting remove this.
- Fix a bug when reading trace.db. This happens when we don't have enough buffer in a page.