### PR TITLE
Pr prof2: handling hpctoolkit prof2 sparse database

### DIFF
--- a/edu.rice.cs.hpcdata.test/src/edu/rice/cs/hpcdata/test/db/version3/DataSummaryTest.java
+++ b/edu.rice.cs.hpcdata.test/src/edu/rice/cs/hpcdata/test/db/version3/DataSummaryTest.java
@@ -15,14 +15,15 @@ public class DataSummaryTest
 	 ***************************/
 	public static void main(String []argv)
 	{
-		final String DEFAULT_FILE = "/home/la5/git/hpctoolkit/BUILD-prof2/hpctoolkit-hpcstruct-sparse-database/thread.db";
+		final String DEFAULT_FILE = "/home/la5/data/prof2/dpr-torch/profile.db";
 		final String filename;
 		if (argv != null && argv.length>0)
 			filename = argv[0];
 		else
 			filename = DEFAULT_FILE;
-		final IdTupleType idTupleType = new IdTupleType();
-		final DataSummary summary_data = new DataSummary(idTupleType);
+		IdTupleType type = IdTupleType.createTypeWithOldFormat();
+		
+		final DataSummary summary_data = new DataSummary(type);
 		try {
 			summary_data.open(filename);			
 			summary_data.printInfo(System.out);
@@ -33,5 +34,4 @@ public class DataSummaryTest
 			e.printStackTrace();
 		}
 	}
-
 }

--- a/edu.rice.cs.hpcdata.test/src/edu/rice/cs/hpcdata/test/db/version3/DataSummaryTest.java
+++ b/edu.rice.cs.hpcdata.test/src/edu/rice/cs/hpcdata/test/db/version3/DataSummaryTest.java
@@ -2,6 +2,7 @@ package edu.rice.cs.hpcdata.test.db.version3;
 
 import java.io.IOException;
 
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.db.version4.DataSummary;
 
 public class DataSummaryTest 
@@ -20,8 +21,8 @@ public class DataSummaryTest
 			filename = argv[0];
 		else
 			filename = DEFAULT_FILE;
-		
-		final DataSummary summary_data = new DataSummary();
+		final IdTupleType idTupleType = new IdTupleType();
+		final DataSummary summary_data = new DataSummary(idTupleType);
 		try {
 			summary_data.open(filename);			
 			summary_data.printInfo(System.out);

--- a/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/collection/ThreadDataCollection4.java
+++ b/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/collection/ThreadDataCollection4.java
@@ -29,8 +29,8 @@ public class ThreadDataCollection4 extends AbstractThreadDataCollection
 		data_plot = new DataPlot();
 		data_plot.open(directory + File.separatorChar + 
 				BaseExperiment.getDefaultDatabaseName(Db_File_Type.DB_PLOT));
-		
-		data_summary = root.getDataSummary();
+
+		data_summary = root.getExperiment().getDataSummary();
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class ThreadDataCollection4 extends AbstractThreadDataCollection
 
 	@Override
 	public int getParallelismLevel() {
-		return data_summary.getMaxLevels();
+		return data_summary.getParallelismLevels();
 	}
 
 	@Override

--- a/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/collection/ThreadDataCollectionFactory.java
+++ b/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/collection/ThreadDataCollectionFactory.java
@@ -52,7 +52,7 @@ public final class ThreadDataCollectionFactory
 			data_file = null;
 			break;
 		}
-		root.setThreadData(data_file);
+		root.getExperiment().setThreadData(data_file);
 		
 		return data_file;
 	}

--- a/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/plot/DataPlot.java
+++ b/edu.rice.cs.hpcdata.tld/src/edu/rice/cs/hpcdata/tld/plot/DataPlot.java
@@ -20,7 +20,7 @@ import edu.rice.cs.hpcdata.db.version4.DataSection;
  *******************************************************************************************/
 public class DataPlot extends DataCommon 
 {
-	private static final String HEADER = "HPCPROF-cmsdb___";
+	private static final String HEADER = "HPCPROF-cctdb___";
 	
 	/*** list of cct. In the future we may need to implement with concurrent list.
 	 *** Right now it's just a simple array or list. Please use it carefully   

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTuple.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTuple.java
@@ -163,7 +163,8 @@ public class IdTuple
 	
 	public boolean isGPU(int level, IdTupleType type) {
 		int kindType = IdTupleType.getKind(kind[level]);
-		return (type.getLabel(kindType).startsWith(IdTupleType.PREFIX_GPU));
+		String kindStr = type.getLabel(kindType);
+		return (kindStr.startsWith(IdTupleType.PREFIX_GPU));
 	}
 	
 	
@@ -192,7 +193,9 @@ public class IdTuple
 			for(int i=0; i<=level; i++) {
 				if (i>0)
 					buff += " ";
-				buff += idTupleType.kindStr(kind[i]) + " " ;
+				int kindInt = IdTupleType.getKind(kind[i]);
+				String kindStr = idTupleType.kindStr(kindInt); 
+				buff += kindStr + " " ;
 
 				switch (IdTupleType.getInterpret(kind[i])) {
 				case IdTupleType.IDTUPLE_IDS_BOTH_VALID:

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
@@ -53,7 +53,7 @@ public class IdTupleType
 
 
 	private final Map<Integer, String> mapIdTuple = new HashMap<>();
-	private Mode mode = Mode.LOGICAL;
+	private Mode mode = Mode.PHYSICAL;
 	
 	
 	public void initOldDatabase() {

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
@@ -1,48 +1,117 @@
 package edu.rice.cs.hpcdata.db;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/***********************************
+ * 
+ * Type definition of id-tuples
+ *
+ * 	see about id-tuple type info in hpctoolkit repository:
+ * <code>
+	https://github.com/HPCToolkit/hpctoolkit/blob/prof2/src/lib/prof-lean/id-tuple.h#L81
+	https://github.com/HPCToolkit/hpctoolkit/blob/prof2/doc/FORMATS.md
+ * </code>	
+ ***********************************/
 public class IdTupleType 
 {
+	public static enum Mode {LOGICAL, PHYSICAL};
+	
+	public final static String PREFIX_GPU = "GPU";
 	
 	// use for backward compatibility
 	// we will convert old database process.thread format
 	// to id-tuples
+	public final static int KIND_RANK    = 2;
+	public final static int KIND_THREAD  = 3;
 	
-	public final static short KIND_SUMMARY = 0;
-	public final static short KIND_NODE    = 1;
-	public final static short KIND_RANK    = 2;
-	public final static short KIND_THREAD  = 3;
-	
-	public final static short KIND_GPU_DEVICE  = 4;
-	public final static short KIND_GPU_CONTEXT = 5;
-	public final static short KIND_GPU_STREAM  = 6;
-	public final static short KIND_CORE        = 7;
-	
-	public final static short KIND_MAX         = 8;
+	public final static String LABEL_RANK   = "Rank";
+	public final static String LABEL_THREAD = "Thread";
 
-	
-	// see https://github.com/HPCToolkit/hpctoolkit/blob/prof2/src/lib/prof-lean/id-tuple.h#L81
-	// for list of kinds in id tuple
-	
-	private final static String KIND_LABEL_SUMMARY = "Summary";
-	private final static String KIND_LABEL_NODE    = "Node";
-	private final static String KIND_LABEL_RANK    = "Rank";
-	private final static String KIND_LABEL_THREAD  = "Thread";
-	
-	private final static String KIND_LABEL_GPU_DEVICE = "Device";
-	private final static String KIND_LABEL_GPU_STREAM = "Stream";
-	private final static String KIND_LABEL_GPU_CTXT   = "Context";
-	
-	private final static String KIND_LABEL_CORE       = "Core";
+	// Constants copied from 
+	// https://github.com/HPCToolkit/hpctoolkit/blob/aa60b422e18f300a0d1ac4f5e365e98e37d45c8a/src/lib/prof-lean/id-tuple.h#L103-L110
 
-	public final static String[] kindLabels  = {KIND_LABEL_SUMMARY, 
-											    KIND_LABEL_NODE,
-												KIND_LABEL_RANK,
-												KIND_LABEL_THREAD,
-												KIND_LABEL_GPU_DEVICE,
-												KIND_LABEL_GPU_CTXT,
-												KIND_LABEL_GPU_STREAM,
-												KIND_LABEL_CORE};
+	/**
+	 * BOTH_VALID: Both logical and physical IDs are presentable. For Viewer present logical ID by default and allow physical on request
+	 */
+	public final static int IDTUPLE_IDS_BOTH_VALID   = 0;
+	/**
+	 * LOGICAL_LOCAL: For Prof2: logical ID should be generated based on shared prefix. 
+	 * For Viewer present physical ID as if it was logical (and warn that something went wrong in Prof2).
+	 */
+	public final static int IDTUPLE_IDS_LOGIC_LOCAL  = 1;
+	/**
+	 * LOGICAL_GLOBAL: For Prof2: logical ID should be generated based on single tuple. For Viewer same as LOGICAL_LOCAL.
+	 */
+	public final static int IDTUPLE_IDS_LOGIC_GLOBAL = 2;
+	/**
+	 * LOGICAL_ONLY: Disregard physical ID, only logical ID is presentable. For Viewer present logical ID and never present physical
+	 */
+	public final static int IDTUPLE_IDS_LOGIC_ONLY   = 3;
 
+
+	private final Map<Integer, String> mapIdTuple = new HashMap<>();
+	private Mode mode = Mode.LOGICAL;
+	
+	
+	public void initOldDatabase() {
+		mapIdTuple.put(KIND_RANK,   LABEL_RANK);
+		mapIdTuple.put(KIND_THREAD, LABEL_THREAD);
+	}
+	
+	/***
+	 * Create id tuple type using the traditional old format
+	 * @return {@code IdTupleType}
+	 */
+	public static IdTupleType createTypeWithOldFormat() {
+		IdTupleType type = new IdTupleType();
+		type.initOldDatabase();
+		return type;
+	}
+	
+	public static int getInterpret(int kind) {
+		return (((kind)>>14) & 0x3);
+	}
+	
+	public static int getKind(int kind) {
+		return ((kind) & ((1<<14)-1));
+	}
+	
+	public static int compose(int kind, int intr) {
+		return (((int)(intr) << 14) | (kind));
+	}
+	
+	
+	
+	/****
+	 * Add a new id tuple type
+	 * @param kind
+	 * @param label
+	 */
+	public void add(int kind, String label) {
+		mapIdTuple.put(kind, label);
+	}
+	
+	
+	/***
+	 * get the label of the id-tuple
+	 * @param kind
+	 * @return
+	 */
+	public String getLabel(int kind) {
+		return mapIdTuple.get(kind);
+	}
+	
+	
+	/***
+	 * get the entry set of the id tuple types
+	 * @return {@code Set<Entry<Integer, String>> }
+	 */
+	public Set<Entry<Integer, String>>  entrySet() {
+		return mapIdTuple.entrySet();
+	}
 	
 	/***
 	 * Conversion from a tuple kind to label string
@@ -50,11 +119,19 @@ public class IdTupleType
 	 * @return String label of a kind 
 	 * @exception java.lang.ArrayIndexOutOfBoundsException if the kind is invalid
 	 */
-	public static String kindStr(short kind)
+	public String kindStr(int kind)
 	{
-		assert(kind>=0 && kind<kindLabels.length);
+		assert(kind>=0 && mapIdTuple != null && mapIdTuple.containsKey(kind));
 		
-		return kindLabels[kind];
+		return mapIdTuple.get(kind);
+	}
+
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
 	}
 
 }

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/IdTupleType.java
@@ -24,12 +24,25 @@ public class IdTupleType
 	// use for backward compatibility
 	// we will convert old database process.thread format
 	// to id-tuples
+	
+	public final static int KIND_SUMMARY = 0;
+	public final static int KIND_NODE    = 1;
 	public final static int KIND_RANK    = 2;
 	public final static int KIND_THREAD  = 3;
+	public final static int KIND_GPUDEVICE  = 4;
+	public final static int KIND_GPUCONTEXT = 5;
+	public final static int KIND_GPUSTREAM  = 6;
+	public final static int KIND_CORE       = 7;
 	
-	public final static String LABEL_RANK   = "Rank";
-	public final static String LABEL_THREAD = "Thread";
-
+	public final static String LABEL_SUMMARY    = "Summary";
+	public final static String LABEL_NODE       = "Node";
+	public final static String LABEL_RANK       = "Rank";
+	public final static String LABEL_THREAD     = "Thread";
+	public final static String LABEL_GPUDEVICE  = "GPUDevice";
+	public final static String LABEL_GPUCONTEXT = "GPUContext";
+	public final static String LABEL_GPUSTREAM  = "GPUStream";
+	public final static String LABEL_CORE		= "Core";
+	
 	// Constants copied from 
 	// https://github.com/HPCToolkit/hpctoolkit/blob/aa60b422e18f300a0d1ac4f5e365e98e37d45c8a/src/lib/prof-lean/id-tuple.h#L103-L110
 
@@ -56,9 +69,15 @@ public class IdTupleType
 	private Mode mode = Mode.PHYSICAL;
 	
 	
-	public void initOldDatabase() {
+	public void initDefaultTypes() {
+		mapIdTuple.put(KIND_SUMMARY,   LABEL_SUMMARY);
+		mapIdTuple.put(KIND_NODE,   LABEL_NODE);
 		mapIdTuple.put(KIND_RANK,   LABEL_RANK);
 		mapIdTuple.put(KIND_THREAD, LABEL_THREAD);
+		mapIdTuple.put(KIND_GPUDEVICE,   LABEL_GPUDEVICE);
+		mapIdTuple.put(KIND_GPUCONTEXT, LABEL_GPUCONTEXT);
+		mapIdTuple.put(KIND_GPUSTREAM,   LABEL_GPUSTREAM);
+		mapIdTuple.put(KIND_CORE, LABEL_CORE);
 	}
 	
 	/***
@@ -67,7 +86,7 @@ public class IdTupleType
 	 */
 	public static IdTupleType createTypeWithOldFormat() {
 		IdTupleType type = new IdTupleType();
-		type.initOldDatabase();
+		type.initDefaultTypes();
 		return type;
 	}
 	

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataCommon.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataCommon.java
@@ -125,7 +125,7 @@ abstract public class DataCommon
 		buffer.get(bytes, 0, MESSAGE_SIZE);
 		String header = new String(bytes);
 		if (!isFileHeaderCorrect(header)) {
-			String msg = "Incorrect header: " + header;
+			String msg = file + " has incorrect header: " + header;
 			throw new IOException(msg);
 		}
 		

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
@@ -93,13 +93,14 @@ public class DataSummary extends DataCommon
 	 * (non-Javadoc)
 	 * @see edu.rice.cs.hpc.data.db.DataCommon#printInfo(java.io.PrintStream)
 	 */
-	public void printInfo( PrintStream out)
+	public void printInfo( PrintStream out )
 	{
 		super.printInfo(out);
+		IdTupleType type = IdTupleType.createTypeWithOldFormat();
 		
 		// print list of id tuples
 		for(IdTuple idt: listIdTuple) {
-			System.out.println(idt);
+			System.out.println(idt.toString(type));
 		}
 		System.out.println();
 
@@ -830,32 +831,4 @@ public class DataSummary extends DataCommon
 				   ", offs: " 	 + offset;
 		}
 	}
-
-	/***************************
-	 * unit test 
-	 * 
-	 * @param argv
-	 ***************************/
-	public static void main(String []argv)
-	{
-		final String DEFAULT_FILE = "/Users/la5/data/sparse/hpctoolkit-database/thread.db";
-		final String filename;
-		if (argv != null && argv.length>0)
-			filename = argv[0];
-		else
-			filename = DEFAULT_FILE;
-		IdTupleType type = IdTupleType.createTypeWithOldFormat();
-		
-		final DataSummary summary_data = new DataSummary(type);
-		try {
-			summary_data.open(filename);			
-			summary_data.printInfo(System.out);
-			summary_data.dispose();	
-			
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-
 }

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
@@ -29,10 +29,10 @@ public class DataSummary extends DataCommon
 	// --------------------------------------------------------------------
 	// constants
 	// --------------------------------------------------------------------
-	private final static String HEADER_MAGIC_STR  = "HPCPROF-pmsdb___";
+	private final static String HEADER_MAGIC_STR  = "HPCPROF-profdb__";
 	private static final int    METRIC_VALUE_SIZE = 8 + 2;
 	private static final int    CCT_RECORD_SIZE   = 4 + 8;
-	private static final int    MAX_LEVELS        = 8;
+	private static final int    MAX_LEVELS        = 18;
 	
 	private static final int    PROFILE_SUMMARY_INDEX = 0;
 	public static final int     PROFILE_SUMMARY       = -1;
@@ -468,7 +468,8 @@ public class DataSummary extends DataCommon
 			
 			for (int j=0; j<item.length; j++) {
 				item.kind[j]  = buffer.getShort();
-				item.index[j] = buffer.getLong();
+				item.physical_index[j] = buffer.getLong();
+				item.logical_index[j]  = buffer.getLong();
 				
 				if (i==0)
 					continue;
@@ -479,7 +480,7 @@ public class DataSummary extends DataCommon
 				
 				// compute the number of appearances of a given kind and level
 				// this is important to know if there's invariant or not
-				Long hash = convertIdTupleToHash(j, item.kind[j], item.index[j]);
+				Long hash = convertIdTupleToHash(j, item.kind[j], item.physical_index[j]);
 				Integer count = mapLevelToHash[j].get(hash);
 				if (count == null) {
 					count = Integer.valueOf(0);
@@ -488,8 +489,8 @@ public class DataSummary extends DataCommon
 				mapLevelToHash[j].put(hash, count);
 				
 				// find min and max for each level
-				minIndex[j] = Math.min(minIndex[j], item.index[j]);
-				maxIndex[j] = Math.min(maxIndex[j], item.index[j]);
+				minIndex[j] = Math.min(minIndex[j], item.physical_index[j]);
+				maxIndex[j] = Math.min(maxIndex[j], item.physical_index[j]);
 			}
 			if (i == 0) {
 				// special treatment for id-tuple = 0: it's a summary profile
@@ -571,9 +572,9 @@ public class DataSummary extends DataCommon
 			for(int j=0; j<idt.length; j++) {
 				if (mapLevelToSkip.get(j) == null) {
 					// we should keep this level
-					short kind = idt.kind[j];
+					short kind = idt.getKind(j);
 					shortVersion.kind[level]  = kind;
-					shortVersion.index[level] = idt.index[j];
+					shortVersion.physical_index[level] = idt.physical_index[j];
 					level++;
 					
 					if (!idTupleTypes.contains(kind))

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataSummary.java
@@ -311,7 +311,7 @@ public class DataSummary extends DataCommon
 			
 			for(int i=0; i<listIdTupleShort.size(); i++) {
 				IdTuple idt  = listIdTupleShort.get(i);
-				strLabels[i] = idt.toString();
+				strLabels[i] = idt.toString(idTupleTypes);
 			}		
 		}
 		return strLabels;

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataTrace.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/db/version4/DataTrace.java
@@ -197,7 +197,7 @@ public class DataTrace extends DataCommon
 		
 		for(int i=0; i< 10; i++)
 		{
-			int rank = (nranks>1 ? r.nextInt(nranks-1) : 1);
+			int rank = 1 + (nranks>1 ? r.nextInt(nranks-1) : 0);
 			int numsamples = getNumberOfSamples(rank);
 			int sample = r.nextInt(numsamples);
 			try {

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/BaseExperiment.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/BaseExperiment.java
@@ -1,10 +1,14 @@
 package edu.rice.cs.hpcdata.experiment;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.EnumMap;
 import java.util.Map;
 
+import edu.rice.cs.hpcdata.db.IdTupleType;
+import edu.rice.cs.hpcdata.db.version4.DataSummary;
+import edu.rice.cs.hpcdata.experiment.extdata.IThreadDataCollection;
 import edu.rice.cs.hpcdata.experiment.scope.RootScope;
 import edu.rice.cs.hpcdata.experiment.scope.RootScopeType;
 import edu.rice.cs.hpcdata.experiment.scope.Scope;
@@ -52,7 +56,10 @@ public abstract class BaseExperiment implements IExperiment
 	
 	private EnumMap<Db_File_Type, String> db_filenames;
 	private int filterNumScopes = 0, filterStatus;
-
+	private IdTupleType idTupleType;
+	private DataSummary dataSummary;
+	private IThreadDataCollection threadData;
+	
 	private BaseTraceAttribute traceAttribute = new TraceAttribute();
 
 	/***
@@ -86,7 +93,68 @@ public abstract class BaseExperiment implements IExperiment
 	}
 	
 	
+	public DataSummary getDataSummary() {
+		if (dataSummary == null) {
+			dataSummary = new DataSummary(getIdTupleType());
+			String databaseDirectory = getDefaultDirectory().getAbsolutePath();
+			String filename = databaseDirectory + File.separator + getDbFilename(BaseExperiment.Db_File_Type.DB_SUMMARY);
+
+			try {
+				dataSummary.open(filename);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		return dataSummary;
+	}
+
+
+	public void setDataSummary(DataSummary dataSummary) {
+		this.dataSummary = dataSummary;
+	}
+
+
+	/***
+	 * set the new id tuple type
+	 * @param idTupleType
+	 */
+	public void setIdTupleType(IdTupleType idTupleType) {
+		this.idTupleType = idTupleType;
+	}
 	
+	
+	/****
+	 * get this database's id tuple type
+	 * @return {@code IdTupleType}
+	 */
+	public IdTupleType getIdTupleType() {
+		if (idTupleType == null) {
+			idTupleType = IdTupleType.createTypeWithOldFormat();
+		}
+			
+		return idTupleType;
+	}
+	
+
+	/****
+	 * set the IThreadDataCollection object to this root
+	 * 
+	 * @param threadData
+	 */
+	public void setThreadData(IThreadDataCollection threadData){
+		this.threadData = threadData;
+	}
+
+
+	/***
+	 * Return the IThreadDataCollection of this root if exists.
+	 * 
+	 * @return
+	 */
+	public IThreadDataCollection getThreadData() {
+		return threadData;
+	}
+
 	/******
 	 * set a database filename
 	 * 

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
@@ -125,23 +125,23 @@ public class FileDB2 implements IFileDB
 				x_val = String.valueOf(proc_id) + "." + String.valueOf(thread_id);
 				
 				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.index[0] = proc_id;
+				tuple.physical_index[0] = (byte) proc_id;
 				
 				tuple.kind[1]  = IdTupleType.KIND_THREAD;
-				tuple.index[1] = thread_id;
+				tuple.physical_index[1] = (byte) thread_id;
 				
 			} else if (isMultiProcess()) 
 			{
 				x_val = String.valueOf(proc_id);					
 				
 				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.index[0] = proc_id;
+				tuple.physical_index[0] = (byte) proc_id;
 			} else if (isMultiThreading()) 
 			{
 				x_val = String.valueOf(thread_id);
 				
 				tuple.kind[0]  = IdTupleType.KIND_THREAD;
-				tuple.index[0] = thread_id;
+				tuple.physical_index[0] = (byte) thread_id;
 			} else {
 				// temporary fix: if the application is neither hybrid nor multiproc nor multithreads,
 				// we just print whatever the order of file name alphabetically
@@ -149,7 +149,7 @@ public class FileDB2 implements IFileDB
 				x_val = String.valueOf(i);
 				
 				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.index[0] = i;
+				tuple.physical_index[0] = (byte) i;
 			}
 			valuesX[i] = x_val;
 			listIdTuples.add(tuple);

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
@@ -37,7 +37,7 @@ public class FileDB2 implements IFileDB
 	private RandomAccessFile file; 
 	
 	private List<IdTuple> listIdTuples;
-	private List<Short>   listIdTupleTypes;
+	private IdTupleType   listIdTupleTypes;
 
 	@Override
 	public void open(String filename, int headerSize, int recordSz)  throws IOException 
@@ -124,32 +124,37 @@ public class FileDB2 implements IFileDB
 			{
 				x_val = String.valueOf(proc_id) + "." + String.valueOf(thread_id);
 				
-				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.physical_index[0] = (byte) proc_id;
+				tuple.setKindAndInterpret(IdTupleType.KIND_RANK, 0);
+				tuple.physical_index[0] = proc_id;
+				tuple.logical_index[0]  = proc_id;
 				
-				tuple.kind[1]  = IdTupleType.KIND_THREAD;
-				tuple.physical_index[1] = (byte) thread_id;
+				tuple.setKindAndInterpret(IdTupleType.KIND_THREAD, 1);
+				tuple.physical_index[1] = thread_id;
+				tuple.logical_index[1]  = thread_id;
 				
 			} else if (isMultiProcess()) 
 			{
 				x_val = String.valueOf(proc_id);					
 				
-				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.physical_index[0] = (byte) proc_id;
+				tuple.setKindAndInterpret(IdTupleType.KIND_RANK, 0);
+				tuple.physical_index[0] = proc_id;
+				tuple.logical_index[0]  = proc_id;
 			} else if (isMultiThreading()) 
 			{
 				x_val = String.valueOf(thread_id);
 				
-				tuple.kind[0]  = IdTupleType.KIND_THREAD;
-				tuple.physical_index[0] = (byte) thread_id;
+				tuple.setKindAndInterpret(IdTupleType.KIND_THREAD, 1);
+				tuple.physical_index[0] = thread_id;
+				tuple.logical_index[1]  = thread_id;
 			} else {
 				// temporary fix: if the application is neither hybrid nor multiproc nor multithreads,
 				// we just print whatever the order of file name alphabetically
 				// this is not the ideal solution, but we cannot trust the value of proc_id and thread_id
 				x_val = String.valueOf(i);
 				
-				tuple.kind[0]  = IdTupleType.KIND_RANK;
-				tuple.physical_index[0] = (byte) i;
+				tuple.setKindAndInterpret(IdTupleType.KIND_RANK, 0);
+				tuple.physical_index[0] = i;
+				tuple.logical_index[0]  = proc_id;
 			}
 			valuesX[i] = x_val;
 			listIdTuples.add(tuple);
@@ -248,18 +253,23 @@ public class FileDB2 implements IFileDB
 	}
 
 	@Override
-	public List<Short> getIdTupleTypes() {
+	public IdTupleType getIdTupleTypes() {
 		if (listIdTupleTypes != null)
 			return listIdTupleTypes;
 		
-		listIdTupleTypes = new ArrayList<>();
+		listIdTupleTypes = new IdTupleType();
 
 		if (isMultiProcess()) {
-			listIdTupleTypes.add(IdTupleType.KIND_RANK);
+			listIdTupleTypes.add(IdTupleType.KIND_RANK, IdTupleType.LABEL_RANK);
 		}
 		if (isMultiThreading()) {
-			listIdTupleTypes.add(IdTupleType.KIND_THREAD);
+			listIdTupleTypes.add(IdTupleType.KIND_THREAD, IdTupleType.LABEL_THREAD);
 		}
 		return listIdTupleTypes;
+	}
+
+	@Override
+	public boolean hasGPU() {
+		return false;
 	}
 }

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/FileDB2.java
@@ -143,9 +143,9 @@ public class FileDB2 implements IFileDB
 			{
 				x_val = String.valueOf(thread_id);
 				
-				tuple.setKindAndInterpret(IdTupleType.KIND_THREAD, 1);
+				tuple.setKindAndInterpret(IdTupleType.KIND_THREAD, 0);
 				tuple.physical_index[0] = thread_id;
-				tuple.logical_index[1]  = thread_id;
+				tuple.logical_index[0]  = thread_id;
 			} else {
 				// temporary fix: if the application is neither hybrid nor multiproc nor multithreads,
 				// we just print whatever the order of file name alphabetically

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/IBaseData.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/IBaseData.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB.IdTupleOption;
 
 /*************************************************************************
@@ -35,7 +36,7 @@ public interface IBaseData
 	 * Retrieve the list of types of id tuples
 	 * @return
 	 */
-	public List<Short>   getIdTupleTypes();
+	public IdTupleType  getIdTupleTypes();
 
 	/****
 	 * retrieve the number of ranks 
@@ -63,6 +64,13 @@ public interface IBaseData
 	 *  @return boolean **/
 	public boolean isHybridRank();
 	
+	
+	/***
+	 * Return {@code true} if the database has GPU measurements
+	 * {@code false} otherwise.
+	 * @return {@code boolean}
+	 */
+	public boolean hasGPU();
 	
 	/***
 	 * Generalized version of {@code isHybridRank}.

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/IFileDB.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/extdata/IFileDB.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 
 
 /*************************************************
@@ -41,6 +42,13 @@ public interface IFileDB
 	 */
 	public int 		getParallelismLevel();
 	
+	
+	/***
+	 * Return true if the database contains GPU measurements
+	 * {@code false} otherwise
+	 * @return
+	 */
+	public boolean  hasGPU();
 	/***
 	 * Get the number of processes or threads.
 	 * 
@@ -62,7 +70,7 @@ public interface IFileDB
 	public long[]	getOffsets();
 	
 	public List<IdTuple> getIdTuple(IdTupleOption option);
-	public List<Short>   getIdTupleTypes();
+	public IdTupleType   getIdTupleTypes();
 	
 	public long 	getLong  (long position) throws IOException;
 	public int  	getInt   (long position) throws IOException;

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/metric/MetricRaw.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/metric/MetricRaw.java
@@ -143,7 +143,7 @@ public class MetricRaw  extends BaseMetric
 		if (s == null) return null;
 		
 		RootScope root = ((Scope)s).getRootScope();
-		IThreadDataCollection threadData = root.getThreadData();
+		IThreadDataCollection threadData = root.getExperiment().getThreadData();
 		
 		MetricValue value = MetricValue.NONE;
 		if (threadData != null)
@@ -243,7 +243,7 @@ public class MetricRaw  extends BaseMetric
 		Scope scope    = (Scope) s;
 		RootScope root = scope.getRootScope();
 		
-		IThreadDataCollection threadData = root.getThreadData();
+		IThreadDataCollection threadData = root.getExperiment().getThreadData();
 		
 		long nodeIndex = scope.getCCTIndex();
 		
@@ -271,7 +271,7 @@ public class MetricRaw  extends BaseMetric
 		// there is no API implementation for reading the whole CCT metrics
 		// TODO: using the old get metric for the new database
 		RootScope root = scope.getRootScope();
-		IThreadDataCollection threadData = root.getThreadData();
+		IThreadDataCollection threadData = root.getExperiment().getThreadData();
 
 		if (threadData == null)
 			// this shouldn't happen, unless hpcprof doesn't generate data properly

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/scope/RootScope.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/scope/RootScope.java
@@ -54,8 +54,8 @@ protected RootScopeType rootScopeType;
 private BaseExperiment experiment;
 private String name;
 
-private IThreadDataCollection threadData;
-private DataSummary dataSummary;
+//private IThreadDataCollection threadData;
+//private DataSummary dataSummary;
 
 //////////////////////////////////////////////////////////////////////////
 //	INITIALIZATION														//
@@ -92,25 +92,6 @@ public Scope duplicate() {
 }
 
 
-/****
- * For database version 4.0 only: retrieve the DataSummary object for this root scope.
- * 
- * 
- * @return DataSummary
- * @throws IOException
- */
-public DataSummary getDataSummary() throws IOException {
-	if (dataSummary == null) {
-		dataSummary = new DataSummary();
-		
-		String filename = experiment.getDefaultDirectory().getAbsolutePath() + File.separatorChar
-				+ experiment.getDbFilename(BaseExperiment.Db_File_Type.DB_SUMMARY);
-		
-		dataSummary.open(filename);
-	}
-	return dataSummary;
-}
-
 
 /******
  * Retrieve (and create) the metric collection based on the version of the database.
@@ -128,7 +109,7 @@ public IMetricValueCollection getMetricValueCollection(Scope scope) throws IOExc
 	if (version == Constants.EXPERIMENT_SPARSE_VERSION) 
 	{
 		if (rootScopeType == RootScopeType.CallingContextTree) {
-			DataSummary data = getDataSummary();
+			DataSummary data = experiment.getDataSummary();
 			return new MetricValueCollection3(data, scope);
 			
 		} else if (rootScopeType == RootScopeType.CallerTree || 
@@ -141,26 +122,6 @@ public IMetricValueCollection getMetricValueCollection(Scope scope) throws IOExc
 }
 
 
-
-/****
- * set the IThreadDataCollection object to this root
- * 
- * @param threadData
- */
-public void setThreadData(IThreadDataCollection threadData)
-{
-	this.threadData = threadData;
-}
-
-
-/***
- * Return the IThreadDataCollection of this root if exists.
- * 
- * @return
- */
-public IThreadDataCollection getThreadData() {
-	return threadData;
-}
 
 //////////////////////////////////////////////////////////////////////////
 //	SCOPE DISPLAY														//

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/xml/BaseExperimentBuilder.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/xml/BaseExperimentBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.BaseExperiment;
 import edu.rice.cs.hpcdata.experiment.Experiment;
 import edu.rice.cs.hpcdata.experiment.ExperimentConfiguration;
@@ -94,7 +95,8 @@ public class BaseExperimentBuilder extends Builder
 
 	private final Map<Integer, CallPath> mapCpidToCallpath;
 	
-
+	private final IdTupleType idTupleType;
+ 
 	//--------------------------------------------------------------------------------------
 	// trace information
 	//--------------------------------------------------------------------------------------
@@ -136,6 +138,8 @@ public class BaseExperimentBuilder extends Builder
 		statusProcedureMap  = new HashMap<Integer, Integer>();
 		
 		mapCpidToCallpath   = new HashMap<>();
+		
+		idTupleType = new IdTupleType();
 		
 		// parse action data structures
 		this.scopeStack   = new Stack<Scope>();
@@ -268,9 +272,20 @@ public class BaseExperimentBuilder extends Builder
 			do_DBFile(BaseExperiment.Db_File_Type.DB_THREADS, attributes, values);
 			break;
 
+		// ---------------------
+		// XML v. 4.0
+		// ---------------------
+		case "IdentifierNameTable":
+			break;
+			
 			// ---------------------
-			// old token from old XML
-			// ---------------------
+		case "Identifier":
+			do_identifier(attributes, values);
+			break;
+			
+		// ---------------------
+		// old token from old XML
+		// ---------------------
 		case "CSPROFILE":
 		case "HPCVIEWER":
 			throw new java.lang.RuntimeException(new OldXMLFormatException());
@@ -340,6 +355,13 @@ public class BaseExperimentBuilder extends Builder
 			end_TraceDBTable();
 			break;
 
+
+		// ---------------------
+		// XML v. 4.0
+		// ---------------------
+		case "IdentifierNameTable":
+			endIdentifierNameTable();
+			break;
 
 			// ignored elements
 			/*
@@ -1095,6 +1117,32 @@ public class BaseExperimentBuilder extends Builder
 		experiment.setTraceAttribute(attribute);
 	}
 
+	
+	/****
+	 * Add id label to the map
+	 * @param attributes
+	 * @param values
+	 */
+	private void do_identifier(String[] attributes, String[] values) {
+		int id = 0;
+		String val = null;
+		for (int i=0; i<attributes.length && i<values.length; i++) {
+			switch (attributes[i]) {
+			case ATTRIBUTE_ID:
+				id = Integer.valueOf(values[i]);
+				break;
+				
+			case ATTRIBUTE_NAME:
+				val = values[i];
+			}
+		}
+		idTupleType.add(id, val);
+	}
+	
+	
+	private void endIdentifierNameTable() {
+		experiment.setIdTupleType(idTupleType);
+	}
 
 
 	//===============================================

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/xml/ExperimentBuilder2.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/xml/ExperimentBuilder2.java
@@ -72,8 +72,6 @@ public class ExperimentBuilder2 extends BaseExperimentBuilder
 	 * parsing the beginning of XML element 
 	 *************************************************************************/
 	public void beginElement(String element, String[] attributes, String[] values) {
-		
-		//TokenXML current = Token2.map(element);
 
 		switch(element)
 		{
@@ -104,9 +102,9 @@ public class ExperimentBuilder2 extends BaseExperimentBuilder
 		default:
 			super.beginElement(element, attributes, values);
 		}
-		//saveTokenContext(current);
 	}
 
+	
 	/*************************************************************************
 	 *	Takes notice of the ending of an element.
 	 ************************************************************************/

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/trace/Filter.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/trace/Filter.java
@@ -40,8 +40,8 @@ public class Filter {
 		for(int i=0; i<idTuple.length; i++) {
 			
 			for (int j=0; j<listTypes.size(); j++) {
-				if (idTuple.kind[i] == listTypes.get(j)) {
-					match = match && ranks[j].matches(idTuple.index[i]);
+				if (idTuple.getKind(i) == listTypes.get(j)) {
+					match = match && ranks[j].matches(idTuple.physical_index[i]);
 					if (!match)
 						return false;
 					else 

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/util/CallPath.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/util/CallPath.java
@@ -37,9 +37,10 @@ public class CallPath
 		int cDepth = maxDepth;
 		Scope cDepthScope = leafScope;
 
-		while(!(cDepthScope.getParentScope() instanceof RootScope) && 
+		while(  cDepthScope != null && cDepthScope.getParent() != null &&
+				!(cDepthScope.getParentScope() instanceof RootScope)   && 
 				(cDepth > depth || !(cDepthScope instanceof CallSiteScope || cDepthScope instanceof ProcedureScope)))
-		{
+		{			
 			cDepthScope = cDepthScope.getParentScope();
 			if((cDepthScope instanceof CallSiteScope) || (cDepthScope instanceof ProcedureScope))
 				cDepth--;

--- a/edu.rice.cs.hpcfilter/src/edu/rice/cs/hpcfilter/dialog/ThreadFilterDialog.java
+++ b/edu.rice.cs.hpcfilter/src/edu/rice/cs/hpcfilter/dialog/ThreadFilterDialog.java
@@ -20,10 +20,6 @@ import edu.rice.cs.hpcdata.db.IdTupleType;
 public class ThreadFilterDialog extends AbstractFilterDialog 
 {
 	public ThreadFilterDialog(Shell parentShell, List<FilterDataItem> items) {
-		this(parentShell, items, null);
-	}
-	
-	public ThreadFilterDialog(Shell parentShell, List<FilterDataItem> items, List<Short> listIdTupleKinds) {
 		super(parentShell, "Select threads to view", 
 				"Please check any threads to be viewed.\nYou can narrow the list by specifying partial name of the threads on the filter.", 
 				items);
@@ -71,18 +67,14 @@ public class ThreadFilterDialog extends AbstractFilterDialog
 
 			int rank = random.nextInt(10);
 			int thread = random.nextInt(100);
-			String label = IdTupleType.kindStr(IdTupleType.KIND_RANK) + " " + rank + " " +
-					   	   IdTupleType.kindStr(IdTupleType.KIND_THREAD) + " " + thread;
+			String label = IdTupleType.LABEL_RANK   + " " + rank + " " +
+					   	   IdTupleType.LABEL_THREAD + " " + thread;
 			
 			FilterDataItem obj = new FilterDataItem(label, i<6, i>3);
 			items.add(obj);
 		}
 		
-		List<Short> listKinds = new ArrayList<Short>();
-		listKinds.add(IdTupleType.KIND_RANK);
-		listKinds.add(IdTupleType.KIND_THREAD);	
-		
-		ThreadFilterDialog dialog = new ThreadFilterDialog(shell, items, listKinds);
+		ThreadFilterDialog dialog = new ThreadFilterDialog(shell, items);
 		if (dialog.open() == Dialog.OK) {
 			System.out.println("result-ok: " + dialog.getReturnCode());
 			items = dialog.getResult();

--- a/edu.rice.cs.hpcremote/src/edu/rice/cs/hpcremote/data/RemoteFilteredBaseData.java
+++ b/edu.rice.cs.hpcremote/src/edu/rice/cs/hpcremote/data/RemoteFilteredBaseData.java
@@ -4,6 +4,7 @@ import java.io.DataOutputStream;
 import java.util.List;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.extdata.IFilteredData;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB.IdTupleOption;
 import edu.rice.cs.hpcdata.trace.FilterSet;
@@ -100,7 +101,7 @@ public class RemoteFilteredBaseData implements IFilteredData {
 		return null;
 	}
 	@Override
-	public List<Short> getIdTupleTypes() {
+	public IdTupleType getIdTupleTypes() {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -122,5 +123,12 @@ public class RemoteFilteredBaseData implements IFilteredData {
 	public List<IdTuple> getDenseListIdTuple(IdTupleOption option) {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+
+	@Override
+	public boolean hasGPU() {
+		// TODO Auto-generated method stub
+		return false;
 	}
 }

--- a/edu.rice.cs.hpctraceviewer.data/.classpath
+++ b/edu.rice.cs.hpctraceviewer.data/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/TraceDataByRank.java
+++ b/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/TraceDataByRank.java
@@ -73,6 +73,9 @@ public class TraceDataByRank implements ITraceDataCollector
 		long minloc = data.getMinLoc(rank);
 		long maxloc = data.getMaxLoc(rank);
 		
+		// corner case: empty samples
+		if (minloc >= maxloc) 
+			return;
 		
 		// get the start location
 		final long startLoc = this.findTimeInInterval(timeStart, minloc, maxloc);

--- a/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/local/SpaceTimeDataControllerLocal.java
+++ b/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/local/SpaceTimeDataControllerLocal.java
@@ -107,7 +107,7 @@ public class SpaceTimeDataControllerLocal extends SpaceTimeDataController
 			traceFilePath = databaseDirectory + File.separator + exp.getDbFilename(BaseExperiment.Db_File_Type.DB_TRACE);
 			
 			RootScope root = (RootScope) exp.getRootScope(RootScopeType.CallingContextTree);
-			DataSummary ds = root.getDataSummary();
+			DataSummary ds = root.getExperiment().getDataSummary();
 			
 			((FileDB4)fileDB).open(ds, databaseDirectory);
 		}

--- a/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/version2/AbstractBaseData.java
+++ b/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/version2/AbstractBaseData.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.extdata.IBaseData;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB.IdTupleOption;
@@ -39,7 +40,7 @@ public abstract class AbstractBaseData implements IBaseData
 	}
 
 	@Override
-	public List<Short>   getIdTupleTypes() {
+	public IdTupleType   getIdTupleTypes() {
 		return baseDataFile.getIdTupleTypes();
 	}
 	
@@ -92,4 +93,8 @@ public abstract class AbstractBaseData implements IBaseData
 		return Constants.SIZEOF_INT + Constants.SIZEOF_LONG;
 	}
 
+	@Override
+	public boolean hasGPU() {
+		return baseDataFile.hasGPU();
+	}
 }

--- a/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/version4/FileDB4.java
+++ b/edu.rice.cs.hpctraceviewer.data/src/edu/rice/cs/hpctraceviewer/data/version4/FileDB4.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.db.version4.DataSummary;
 import edu.rice.cs.hpcdata.db.version4.DataTrace;
 import edu.rice.cs.hpcdata.experiment.BaseExperiment;
@@ -89,7 +90,7 @@ public class FileDB4 implements IFileDB
 
 	@Override
 	public int getParallelismLevel() {
-		return dataSummary.getMaxLevels();
+		return dataSummary.getParallelismLevels();
 	}
 
 	@Override
@@ -129,8 +130,12 @@ public class FileDB4 implements IFileDB
 	}
 
 	@Override
-	public List<Short> getIdTupleTypes() {
-		return dataSummary.getIdTupleTypes();
+	public IdTupleType getIdTupleTypes() {
+		return dataSummary.getIdTupleType();
 	}
 
+	@Override
+	public boolean  hasGPU() {
+		return dataSummary.hasGPU();
+	}
 }

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/TracePart.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/TracePart.java
@@ -5,8 +5,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import java.util.HashMap;
-import java.util.List;
-
 import javax.annotation.PostConstruct;
 
 import org.eclipse.swt.SWT;
@@ -50,7 +48,6 @@ import edu.rice.cs.hpctraceviewer.ui.summary.HPCSummaryView;
 import edu.rice.cs.hpctraceviewer.ui.util.IConstants;
 import edu.rice.cs.hpctraceviewer.ui.util.Utility;
 import edu.rice.cs.hpcbase.ViewerDataEvent;
-import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.BaseExperiment;
 import edu.rice.cs.hpcdata.experiment.extdata.IBaseData;
 import edu.rice.cs.hpcdata.util.OSValidator;
@@ -412,19 +409,8 @@ public class TracePart implements ITracePart, IPartListener, IPropertyChangeList
 			tbtmTraceView.setInput(stdc);
 			
 			IBaseData data = stdc.getBaseData();
-			List<Short> listIdTupleTypes = data.getIdTupleTypes();
-			boolean hasGPU = false; 
-			
-			// check whether this database has gpu profile or not
-			for (Short type: listIdTupleTypes) {
-				if (IdTupleType.KIND_GPU_CONTEXT == type) {
-					tbtmBlameView.setInput(stdc);
-					hasGPU = true;
-					
-					break;
-				}
-			}
-			if (!hasGPU) {
+
+			if (!data.hasGPU()) {
 				tbtmBlameView.dispose();
 				tbtmSummaryView.setAnalysisTool(IPixelAnalysis.EMPTY);
 			} else {

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/CpuBlameAnalysis.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/blamestat/CpuBlameAnalysis.java
@@ -154,7 +154,7 @@ public class CpuBlameAnalysis implements IPixelAnalysis
 		IdTuple tag = listTuples.get(process);
 		int rank = (int) tag.getIndex(IdTupleType.KIND_RANK);
 				
-		isCpuThread = !tag.hasKind(IdTupleType.KIND_GPU_CONTEXT);
+		isCpuThread = !tag.isGPU(dataTraces.getExperiment().getIdTupleType());
 
 		RGB rgb = detailData.palette.getRGB(pixelValue);
 		ProcedureColor procColor = colorTable.getProcedureNameByColorHash(rgb.hashCode());

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/depth/DepthPaintThread.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/depth/DepthPaintThread.java
@@ -49,4 +49,10 @@ public class DepthPaintThread extends BasePaintThread {
 		gc.dispose();
 		return new ImagePosition(linenum, image);
 	}
+
+	@Override
+	public void dispose() {
+		if (image != null) image.dispose();
+		if (gc != null) gc.dispose();
+	}
 }

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/handlers/FilterRanks.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/handlers/FilterRanks.java
@@ -69,7 +69,7 @@ public class FilterRanks
         // This list needs to be optimized.
         
         for(int i=0, j=0; i<listDenseIds.size(); i++) {
-        	items[i] = listDenseIds.get(i).toString();
+        	items[i] = listDenseIds.get(i).toString(filteredBaseData.getIdTupleTypes());
         	if (j<listIds.size() && listDenseIds.get(i) == listIds.get(j)) {
         		checked[i] = true;
         		j++;

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/internal/BasePaintThread.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/internal/BasePaintThread.java
@@ -162,7 +162,13 @@ public abstract class BasePaintThread implements Callable<List<ImagePosition>>
 	 * @return
 	 */
 	abstract protected ImagePosition finalizePaint(int linenum);
-		
+	
+	
+	/****
+	 * Free allocated resources. To be called by the end of the sessionS
+	 */
+	abstract public void dispose();
+	
 	/***
 	 * basic method to paint on a gc
 	 * 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/CanvasAxisY.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/CanvasAxisY.java
@@ -249,7 +249,7 @@ public class CanvasAxisY extends AbstractAxisCanvas
 			IdTuple id  = listTuples.get(process); 
 			int level   = Math.min(event.x / columnWidth, id.length-1);
 			
-			return id.toString(level);
+			return id.toString(level, traceData.getIdTupleTypes());
 		}
 		
 		

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/CanvasAxisY.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/CanvasAxisY.java
@@ -161,7 +161,7 @@ public class CanvasAxisY extends AbstractAxisCanvas
 
 				int currentColor;
 				
-				if (idtupleOld != null && idtupleOld.index.length>j && idtuple.index[j]!= idtupleOld.index[j]) {
+				if (idtupleOld != null && idtupleOld.physical_index.length>j && idtuple.physical_index[j]!= idtupleOld.physical_index[j]) {
 					// make sure the current color is different than the previous one
 					currentColor = 1-oldColorIndex[j];
 				} else {

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/DetailPaintThread.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/DetailPaintThread.java
@@ -98,14 +98,23 @@ public class DetailPaintThread
 			}
 		}
 	}
+	
+	@Override
+	public void dispose() {
+		if (lineFinal != null)    lineFinal.dispose();
+		if (lineOriginal != null) lineOriginal.dispose();
+				
+		if (gcFinal != null)    gcFinal.dispose();
+		if (gcOriginal != null) gcOriginal.dispose();
+	}
+	
 
 	@Override
 	protected void initPaint(/*Device device, */int width, int height) {
-
-		lineFinal = new Image(device, width, height);
+		lineFinal    = new Image(device, width, height);
 		lineOriginal = new Image(device, width, 1);
 		
-		gcFinal = new GC(lineFinal);
+		gcFinal    = new GC(lineFinal);
 		gcOriginal = new GC(lineOriginal);		
 	}
 

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/DetailViewPaint.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/DetailViewPaint.java
@@ -13,6 +13,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.extdata.IBaseData;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB.IdTupleOption;
 import edu.rice.cs.hpcsetting.preferences.PreferenceConstants;
@@ -152,9 +153,11 @@ public class DetailViewPaint extends BaseViewPaint
 		if (m == null || m.size()==0)
 			return;
 		
+		final IdTupleType idTupleType = controller.getBaseData().getIdTupleTypes();
+		
 		m.forEach((k,v) -> {
-			IdTuple idt = listIdTuples.get(k);
-			System.out.println(idt + " has invalid cpid: " + v);
+			IdTuple idt = listIdTuples.get(k);			
+			System.out.println(idt.toString(idTupleType) + " has invalid cpid: " + v);
 		});
 
 	}

--- a/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/SpaceTimeDetailCanvas.java
+++ b/edu.rice.cs.hpctraceviewer.ui/src/edu/rice/cs/hpctraceviewer/ui/main/SpaceTimeDetailCanvas.java
@@ -47,6 +47,7 @@ import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 
 import edu.rice.cs.hpcdata.db.IdTuple;
+import edu.rice.cs.hpcdata.db.IdTupleType;
 import edu.rice.cs.hpcdata.experiment.extdata.IBaseData;
 import edu.rice.cs.hpcdata.experiment.extdata.IFileDB.IdTupleOption;
 import edu.rice.cs.hpctraceviewer.ui.base.ISpaceTimeCanvas;
@@ -653,7 +654,10 @@ public class SpaceTimeDetailCanvas extends AbstractTimeCanvas
         if (proc_end>=listIdTuples.size())
         	proc_end = listIdTuples.size()-1;
         
-        processLabel.setText("Rank Range: [" + listIdTuples.get(proc_start).toString() + ", " + listIdTuples.get(proc_end).toString() +"]");
+        IdTupleType type = stData.getExperiment().getIdTupleType();
+        processLabel.setText("Rank Range: [" + listIdTuples.get(proc_start).toString(type) 
+        									 + ", " + listIdTuples.get(proc_end).toString(type) 
+        									 + "]");
         processLabel.setSize(processLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
 	}
@@ -691,10 +695,9 @@ public class SpaceTimeDetailCanvas extends AbstractTimeCanvas
 		if ( selectedProc >= 0 && selectedProc < listIdTuples.size() && listIdTuples.size()>1 ) {
 			
 			IdTuple idtuple = listIdTuples.get(selectedProc);
-	        final String buffer = label + "(" + 
-	        							  formatTime.format(selectedTime) + timeUnit + ", " + 
-	        							  idtuple.toString() + 
-	        							  ")";
+			String procStr  = idtuple.toString(traceData.getIdTupleTypes());
+			String timeStr  = formatTime.format(selectedTime) + timeUnit;
+	        final String buffer = label + "(" + timeStr + ", " +  procStr + ")";
 
 	        crossHairLabel.setText(buffer);
 


### PR DESCRIPTION
This includes:
- backward compatibility with old/traditional databases
- support for triplet id-tuples
- refine unit test for sparse databases
- refactoring the code to handle id-tuples
