### PR TITLE
Fix issue #223 (incorrect cost attribution in the flat view)

### DIFF
--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/BaseExperimentWithMetrics.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/BaseExperimentWithMetrics.java
@@ -20,6 +20,7 @@ import edu.rice.cs.hpcdata.experiment.metric.FinalMetric;
 import edu.rice.cs.hpcdata.experiment.metric.IMetricManager;
 import edu.rice.cs.hpcdata.experiment.metric.Metric;
 import edu.rice.cs.hpcdata.experiment.metric.MetricComparator;
+import edu.rice.cs.hpcdata.experiment.metric.MetricRaw;
 import edu.rice.cs.hpcdata.experiment.metric.MetricType;
 import edu.rice.cs.hpcdata.experiment.metric.MetricValue;
 import edu.rice.cs.hpcdata.experiment.metric.BaseMetric.VisibilityType;
@@ -51,7 +52,6 @@ implements IMetricManager, ListEventListener<BaseMetric>
 	/**
 	 * map ID to the metric descriptor
 	 */
-	//private Map<Integer, BaseMetric> mapIndexToMetric;	
 	private MutableIntObjectMap<BaseMetric> mapIndexToMetric;
 
 	
@@ -94,6 +94,24 @@ implements IMetricManager, ListEventListener<BaseMetric>
 		metrics.addListEventListener(this);
 	}
 
+	
+	@Override
+	public MetricRaw getCorrespondentMetricRaw(BaseMetric metric) {
+		var rawMetrics = getRawMetrics();
+		MetricRaw correspondentRawMetric = null;
+
+		var metricName = metric.getDisplayName();
+		var metricBaseName = metricName.replace(":Sum", "");
+		
+		for(var rm: rawMetrics) {
+			if (rm.getDisplayName().equals(metricBaseName)) {
+				correspondentRawMetric = (MetricRaw) rm;
+				break;
+			}
+		}
+		return correspondentRawMetric;
+	}
+	
 	
 	protected void copyMetric(Scope target, Scope source, int src_i, int targ_i, MetricValuePropagationFilter filter) {
 		if (filter.doPropagation(source, target, src_i, targ_i)) {

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/metric/IMetricManager.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/metric/IMetricManager.java
@@ -13,6 +13,20 @@ import edu.rice.cs.hpcdata.experiment.scope.Scope;
 public interface IMetricManager 
 {
 	/***
+	 * Get the correlated raw metric version of the given base metric.
+	 * <br/>
+	 * Database version 2.x or older has no correlation between the base
+	 * metric and the raw metric. This method will return if the base 
+	 * metric has its correspondent raw metric.
+	 * 
+	 * @param metric
+	 * 			The base metric
+	 * @return {@code MetricRae}
+	 * 			The correspondent raw metric
+	 */
+	public MetricRaw getCorrespondentMetricRaw(BaseMetric metric);
+	
+	/***
 	 * Returns a metric descriptor given a metric id
 	 * @param ID String metric id
 	 * @return {@code BaseMetric}

--- a/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/scope/visitors/FlatViewScopeVisitor.java
+++ b/edu.rice.cs.hpcdata/src/edu/rice/cs/hpcdata/experiment/scope/visitors/FlatViewScopeVisitor.java
@@ -445,6 +445,18 @@ public class FlatViewScopeVisitor implements IScopeVisitor
 				hash_id.append(SEPARATOR_ID);
 				hash_id.append(linenum);
 			}
+		} else if (scope instanceof LineScope) {
+			// fix issue #223 (incorrect cost attribution for line scopes)
+			// reconstruct the procedure and file scope:
+			//  since the same procedure scopes may have the different flat ids,
+			//  we need to regenerate the id of line scope which now depends 
+			//  on the id of the parent.
+			//  It looks like this only happens with prof2 database
+			var parent = scope.getParentScope();
+			var parentId = getID(parent);
+			
+			hash_id.append(SEPARATOR_ID);
+			hash_id.append(parentId);
 		}
 		return hash_id.toString();
 	}

--- a/edu.rice.cs.hpcsetting/src/edu/rice/cs/hpcsetting/preferences/ViewerPreferenceManager.java
+++ b/edu.rice.cs.hpcsetting/src/edu/rice/cs/hpcsetting/preferences/ViewerPreferenceManager.java
@@ -29,6 +29,7 @@ public class ViewerPreferenceManager extends AbstractPreferenceManager
 	public static final String []DEFAULT_CALLTO   = new String[] {"\u00bb", "\u21C9", "\u21D2", "\u21D8", "\u21DB", "\u21E5", "\u21F2", "\u27A5", "\u2937", "\u2B0A", "\u2B0E", "\u2B46", "\u2B78", "\u2BA1", "\u2BA9", "\u2BAF", "\u2BB1"};
 	public static final String []DEFAULT_CALLFROM = new String[] {"\u00ab", "\u21C7", "\u21D0", "\u21D6", "\u21DA", "\u21E4", "\u21F1", "\u27A6", "\u293A", "\u2B09", "\u2B11", "\u2B45", "\u2B76", "\u2BA2", "\u2BAA", "\u2BAC", "\u2BB2"};
 
+	// fix issue #207 (some platforms don't support unicode)
  	public static final int DEFAULT_CALLSITE_INDEX = 0;
 
  	private static final String EMPTY = "";
@@ -65,16 +66,10 @@ public class ViewerPreferenceManager extends AbstractPreferenceManager
 									   FontManager.getCallsiteGlyphDefaultFont().getFontData());
 		
 		// fix issue #207 (some platforms don't support unicode)
-		// check if the encoding supports UTF or not.
-		// Most systems that have ANSI platform has no UTF support
-		// Example: ANSI_X3.4-1968 is basically an ASCII set
-		int indexDefault = DEFAULT_CALLSITE_INDEX;
-		var encoding = System.getProperty("file.encoding");
-		if (encoding.startsWith("ANSI")) 
-			indexDefault = 0;
+		// Use ASCII character by default
 
-		store.setDefault(PreferenceConstants.ID_CHAR_CALLTO, DEFAULT_CALLTO[indexDefault]);
-		store.setDefault(PreferenceConstants.ID_CHAR_CALLFROM, DEFAULT_CALLFROM[indexDefault]);
+		store.setDefault(PreferenceConstants.ID_CHAR_CALLTO, DEFAULT_CALLTO[DEFAULT_CALLSITE_INDEX]);
+		store.setDefault(PreferenceConstants.ID_CHAR_CALLFROM, DEFAULT_CALLFROM[DEFAULT_CALLSITE_INDEX]);
 	}
 	
 	

--- a/edu.rice.cs.hpcsetting/src/edu/rice/cs/hpcsetting/preferences/ViewerPreferenceManager.java
+++ b/edu.rice.cs.hpcsetting/src/edu/rice/cs/hpcsetting/preferences/ViewerPreferenceManager.java
@@ -29,7 +29,7 @@ public class ViewerPreferenceManager extends AbstractPreferenceManager
 	public static final String []DEFAULT_CALLTO   = new String[] {"\u00bb", "\u21C9", "\u21D2", "\u21D8", "\u21DB", "\u21E5", "\u21F2", "\u27A5", "\u2937", "\u2B0A", "\u2B0E", "\u2B46", "\u2B78", "\u2BA1", "\u2BA9", "\u2BAF", "\u2BB1"};
 	public static final String []DEFAULT_CALLFROM = new String[] {"\u00ab", "\u21C7", "\u21D0", "\u21D6", "\u21DA", "\u21E4", "\u21F1", "\u27A6", "\u293A", "\u2B09", "\u2B11", "\u2B45", "\u2B76", "\u2BA2", "\u2BAA", "\u2BAC", "\u2BB2"};
 
- 	public static final int DEFAULT_CALLSITE_INDEX = 2;
+ 	public static final int DEFAULT_CALLSITE_INDEX = 0;
 
  	private static final String EMPTY = "";
 	


### PR DESCRIPTION
This happens with prof2 database where the same procedure of the same
file and the same module has different flat id (since it has different
contexts in the CCT).
The solution is to regenerate the flat id of the line scope to depend on
the parent, not only its flat id.